### PR TITLE
Fix Asciidoc slide rendering

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -22,9 +22,9 @@
     <property name="maven.executable"      value="mvn"/>
     <property name="git.executable"        value="git"/>
     <property name="asciidoc.executable"   value="asciidoctor"/>
-    <property name="asciidoc.backends"     value="asciidoctor-backends"/>
+    <property name="asciidoc.backends"     value="asciidoctor-deck.js"/>
     <property name="asciidoc.backends.dir" value="${basedir}/../${asciidoc.backends}"/>
-    <property name="asciidoc.backends.url" value="git://github.com/asciidoctor/asciidoctor-backends.git"/>
+    <property name="asciidoc.backends.url" value="git://github.com/asciidoctor/asciidoctor-deck.js"/>
     <property name="deck.js"               value="deck.js"/>
     <property name="deck.js.dir"           value="${basedir}/../${deck.js}"/>
     <property name="deck.js.url"           value="git://github.com/imakewebthings/deck.js.git"/>
@@ -182,7 +182,7 @@
             <mkdir dir="@{dir}/build"/>
             <echo message="Processing @{input} in @{dir}"/>
             <exec executable="${asciidoc.executable}" dir="@{dir}">
-                <arg line="-T ${asciidoc.backends.dir}/haml @{input}"/>
+                <arg line="-T ${asciidoc.backends.dir}/templates/haml @{input}"/>
             </exec>
         </sequential>
     </macrodef>


### PR DESCRIPTION
The deck.js backend has changed its location. Fix the URL to the repo
and the command line to generate the slides.

Addresses https://github.com/belaban/workshop/issues/9
